### PR TITLE
Implement Google OAuth via Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ This repository contains a minimal Node.js (Express) server with a Vue.js front-
    ```sh
    npm start
    ```
-3. Open `http://localhost:3000` in your browser to view the app.
+3. Set the `SUPABASE_URL` and `SUPABASE_KEY` environment variables before running
+   the server. These are available from your Supabase project's settings.
+4. Open `http://localhost:3000` in your browser to view the app.

--- a/index.js
+++ b/index.js
@@ -6,10 +6,20 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const upload = multer();
 
+// Supabase configuration passed to the client
+const SUPABASE_URL = process.env.SUPABASE_URL || '';
+const SUPABASE_KEY = process.env.SUPABASE_KEY || '';
+
 // Serve static files from the public directory
 app.use(express.static(path.join(__dirname, 'public')));
 // Parse incoming JSON bodies
 app.use(express.json());
+
+// Serve a small script with Supabase credentials
+app.get('/config.js', (req, res) => {
+  res.type('application/javascript');
+  res.send(`window.SUPABASE_URL = ${JSON.stringify(SUPABASE_URL)};\nwindow.SUPABASE_KEY = ${JSON.stringify(SUPABASE_KEY)};`);
+});
 
 // Endpoint to handle uploaded image and log its size
 app.post('/submit', upload.single('image'), (req, res) => {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@supabase/supabase-js": "^2.52.0",
     "express": "^4.18.2",
     "multer": "^2.0.1"
   }

--- a/public/app.js
+++ b/public/app.js
@@ -1,13 +1,34 @@
 const { createApp } = Vue;
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+
+const supabaseUrl = window.SUPABASE_URL;
+const supabaseKey = window.SUPABASE_KEY;
+const supabase = createClient(supabaseUrl, supabaseKey);
 
 createApp({
   data() {
     return {
       message: 'Hello from Vue!',
-      imageFile: null
+      imageFile: null,
+      userEmail: null
     };
   },
+  mounted() {
+    this.updateUser();
+    supabase.auth.onAuthStateChange(() => this.updateUser());
+  },
   methods: {
+    async updateUser() {
+      const { data: { session } } = await supabase.auth.getSession();
+      this.userEmail = session ? session.user.email : null;
+    },
+    async signIn() {
+      await supabase.auth.signInWithOAuth({ provider: 'google' });
+    },
+    async signOut() {
+      await supabase.auth.signOut();
+      await this.updateUser();
+    },
     handleFileChange(event) {
       this.imageFile = event.target.files[0];
     },

--- a/public/index.html
+++ b/public/index.html
@@ -4,16 +4,20 @@
   <meta charset="UTF-8">
   <title>Vue Express App</title>
   <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+  <script src="/config.js"></script>
 </head>
 <body>
   <div id="app">
     <div>{{ message }}</div>
+    <div v-if="userEmail">Signed in as {{ userEmail }}</div>
+    <button v-if="!userEmail" type="button" @click="signIn">Sign in with Google</button>
+    <button v-else type="button" @click="signOut">Sign Out</button>
     <form id="imageForm" @submit.prevent="submitForm">
       <input id="imageInput" type="file" accept="image/*" capture="environment" @change="handleFileChange" />
       <button type="submit">Submit</button>
     </form>
   </div>
 
-  <script src="app.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `@supabase/supabase-js` dependency
- expose Supabase credentials to the browser through `/config.js`
- build client-side login/logout flow using Supabase Google OAuth
- show login state in the page
- document required Supabase environment variables
- integrate Supabase auth into Vue app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ac3ea25908325a1f48262d3bf44d1