### PR TITLE
Convert Supabase setup to Node script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ This repository contains a minimal Node.js (Express) server with a Vue.js front-
    ```sh
    npm start
    ```
-3. Set the `SUPABASE_URL` and `SUPABASE_KEY` environment variables before running
+3. Set the `SUPABASE_DB_URL` and `SUPABASE_KEY` environment variables before running
    the server. These are available from your Supabase project's settings.
 4. Open `http://localhost:3000` in your browser to view the app.
+
+## Supabase Users Table
+
+Create a `users` table in your Supabase project so the application can store
+information about everyone that signs in with Google. Run the setup script to
+create the required tables:
+
+```sh
+SUPABASE_DB_URL=postgres://<user>:<password>@<host>:<port>/<db> npm run setup-db
+```
+
+Replace the connection string with the Database URL from your Supabase project.
+The script will create any missing tables as we add them.

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const PORT = process.env.PORT || 3000;
 const upload = multer();
 
 // Supabase configuration passed to the client
-const SUPABASE_URL = process.env.SUPABASE_URL || '';
+const SUPABASE_URL = process.env.SUPABASE_DB_URL || '';
 const SUPABASE_KEY = process.env.SUPABASE_KEY || '';
 
 // Serve static files from the public directory

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "node --version",
-    "start": "node index.js"
+    "start": "node index.js",
+    "setup-db": "node supabase/setupTables.js"
   },
   "keywords": [],
   "author": "",
@@ -14,6 +15,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.52.0",
     "express": "^4.18.2",
-    "multer": "^2.0.1"
+    "multer": "^2.0.1",
+    "pg": "^8.11.5"
   }
 }

--- a/supabase/setupTables.js
+++ b/supabase/setupTables.js
@@ -1,0 +1,29 @@
+const { Client } = require('pg');
+
+async function main() {
+  const connectionString = process.env.SUPABASE_DB_URL;
+  if (!connectionString) {
+    console.error('SUPABASE_DB_URL environment variable is required');
+    process.exit(1);
+  }
+
+  const client = new Client({ connectionString });
+  await client.connect();
+  try {
+    await client.query('create extension if not exists "uuid-ossp"');
+    await client.query(`create table if not exists users (
+      id uuid default uuid_generate_v4() primary key,
+      email text not null unique,
+      name text,
+      stripeAccountId text
+    )`);
+    console.log('Supabase tables created or already exist');
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch(err => {
+  console.error('Error setting up tables:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- remove SQL snippet from README
- provide Node.js script to create Supabase tables
- wire script as `npm run setup-db`
- align environment variable names across server and setup script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bc40f5f6c8325b44e8a89ee655391